### PR TITLE
fix #4: The property `size` must be predefined named size or size wit…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ render() {
   return (
     <>
       <Checkmark size='xxLarge' />
-      <Checkmark size={96} />
+      <Checkmark size='96px' />
     </>
   )
 }
@@ -53,8 +53,8 @@ render() {
 render() {
   return (
     <>
-      <Checkmark size={128} color='blue' />
-      <Checkmark size={256} color='#223344'/>
+      <Checkmark size='128px' color='blue' />
+      <Checkmark size='256px' color='#223344'/>
     </>
   )
 }

--- a/examples/src/example.js
+++ b/examples/src/example.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
-
-import './example.css';
 import { Checkmark } from 'src/checkmark';
 
-export const App = () => {
+import './example.css';
+
+function App() {
   const sizes = ['small', 'medium', 'large', 'xLarge', 'xxLarge', 96, 144];
   return (
     <div>
@@ -17,7 +17,9 @@ export const App = () => {
       {sizes.map((size) => {
         return (
           <div className={'showcase d-flex'}>
-            <h3 className='w-25'>size={typeof size === 'string' ? `'${size}'` : size}</h3>
+            <h3 className='w-25'>
+              size={typeof size === 'string' ? `'${size}'` : `${size}px`}
+            </h3>
             <Checkmark className='w-25' size={size} />
             <Checkmark className='w-25' size={size} color={'blue'} />
             <Checkmark className='w-25' size={size} color={'#223344'} />

--- a/src/checkmark.js
+++ b/src/checkmark.js
@@ -6,19 +6,20 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
+
 import './checkmark.css';
 
-export const namedSizes = {
-  small: 16,
-  medium: 24,
-  large: 52,
-  xLarge: 72,
-  xxLarge: 96,
+const PREDEFINED_SIZE_MAP = {
+  small: '16px',
+  medium: '24px',
+  large: '52px',
+  xLarge: '72px',
+  xxLarge: '96px',
 };
 
-export const Checkmark = ({ size, color }) => {
-  const actualSize = namedSizes[size] || size;
-  const style = { width: actualSize, height: actualSize };
+export function Checkmark({ size, color }) {
+  const computedSize = PREDEFINED_SIZE_MAP[size] || size;
+  const style = { width: computedSize, height: computedSize };
   if (color) {
     style['--checkmark-fill-color'] = color;
   }
@@ -34,10 +35,10 @@ export const Checkmark = ({ size, color }) => {
       <path className='checkmark__check' fill='none' d='M14.1 27.2l7.1 7.2 16.7-16.8' />
     </svg>
   );
-};
+}
 
 Checkmark.propTypes = {
-  size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  size: PropTypes.string,
   color: PropTypes.string,
 };
 


### PR DESCRIPTION
Thanks @charan1973 help, I can reproduce the issue now. It is a bit hard for me to support number for property `size`. I decided to remove the number support. So from now on, you need to specify `192px` instead of `192`. I think this makes sense to remove the warning. But if you dont care about the warning, `192` should still work for you. 